### PR TITLE
refactor: add type hints for request matcher for better usability

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('LICENSE') as f:
 
 setup(
     name='http_request_recorder',
-    version='0.2.1',
+    version='0.2.2',
     description='A package to record an respond to http requests, primarily for use in black box testing.',
     long_description=readme,
     author='',


### PR DESCRIPTION
Neulich erst wieder darüber gestolpert, dass so eine API ohne type hints schwieriger zu benutzen ist.

Schaut mal drüber ob hier noch was fehlt und macht dann gern schon den merge.